### PR TITLE
Added task to upgrade/precache flutter

### DIFF
--- a/PubNet.Worker/PubNet.Worker.csproj
+++ b/PubNet.Worker/PubNet.Worker.csproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CliWrap" Version="3.6.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />

--- a/PubNet.Worker/Tasks/FlutterUpgradeTask.cs
+++ b/PubNet.Worker/Tasks/FlutterUpgradeTask.cs
@@ -1,0 +1,52 @@
+using CliWrap;
+using PubNet.Worker.Models;
+
+namespace PubNet.Worker.Tasks;
+
+public class FlutterUpgradeTask : BaseScheduledWorkerTask
+{
+	private static readonly TimeSpan MaxBackOffInterval = TimeSpan.FromDays(3);
+
+	private ILogger<FlutterUpgradeTask>? _logger;
+
+	/// <inheritdoc />
+	public FlutterUpgradeTask(TimeSpan interval) : base(interval, DateTime.Now, nameof(FlutterUpgradeTask), true)
+	{
+	}
+
+	/// <inheritdoc />
+	protected override async Task<WorkerTaskResult> InvokeScheduled(IServiceProvider services, CancellationToken cancellationToken = default)
+	{
+		_logger ??= services.GetRequiredService<ILogger<FlutterUpgradeTask>>();
+
+		var upgradeResult = await RunFlutterCommand(_logger, "upgrade", cancellationToken);
+		if (!upgradeResult.IsSuccess())
+			return upgradeResult;
+
+		return await RunFlutterCommand(_logger, "precache", cancellationToken);
+	}
+
+	private async Task<WorkerTaskResult> RunFlutterCommand(ILogger logger, string command, CancellationToken cancellationToken = default)
+	{
+		var result = await Cli.Wrap("flutter")
+			.WithArguments(command)
+			.WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
+			.WithStandardErrorPipe(PipeTarget.ToStream(Console.OpenStandardError()))
+			.ExecuteAsync(cancellationToken);
+
+		if (result.ExitCode == 0) return WorkerTaskResult.Requeue;
+
+		// exponential back-off
+		Interval *= 2;
+		if (Interval >= MaxBackOffInterval)
+		{
+			logger.LogError("Flutter {Command} failed too many times. Restart the worker to enable this task again", command);
+
+			return WorkerTaskResult.Failed;
+		}
+
+		logger.LogError("Flutter {Command} failed. Will try again in {Interval}", command, Interval);
+
+		return WorkerTaskResult.FailedRecoverable;
+	}
+}

--- a/PubNet.Worker/Worker.cs
+++ b/PubNet.Worker/Worker.cs
@@ -32,6 +32,7 @@ public class Worker : BackgroundService
 	{
 		_taskQueue.Enqueue(new CleanupOldPendingArchivesTask(GetInterval("Worker:PendingCleanupInterval")));
 		_taskQueue.Enqueue(new MissingPackageVersionAnalysisQueuingTask(GetInterval("Worker:QueueMissingAnalysisInterval")));
+		_taskQueue.Enqueue(new FlutterUpgradeTask(GetInterval("Worker:FlutterUpgradeInterval")));
 
 		await base.StartAsync(cancellationToken);
 	}

--- a/PubNet.Worker/appsettings.Development.json
+++ b/PubNet.Worker/appsettings.Development.json
@@ -26,7 +26,8 @@
   "Worker": {
     "TaskInterval": "00:00:30",
     "PendingCleanupInterval": "00:04:00",
-    "QueueMissingAnalysisInterval": "00:01:00"
+    "QueueMissingAnalysisInterval": "00:01:00",
+    "FlutterUpgradeInterval": "00:10:00"
   },
   "PackageStorage": {
     "Path": "../packages"

--- a/PubNet.Worker/appsettings.json
+++ b/PubNet.Worker/appsettings.json
@@ -10,6 +10,7 @@
   "Worker": {
     "TaskInterval": "00:05:00",
     "PendingCleanupInterval": "01:00:00",
-    "QueueMissingAnalysisInterval": "00:15:00"
+    "QueueMissingAnalysisInterval": "00:15:00",
+    "FlutterUpgradeInterval": "01:00:00:00"
   }
 }


### PR DESCRIPTION
This should fix #3.

I added a task to the worker that runs when the worker first starts up and, by default, once per day to upgrade flutter to the latest stable version (implicitly building the flutter tool) and then run `flutter precache` to download common dependencies (like `sky_engine`).
